### PR TITLE
Add support for Gnome Shell 42

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,5 +4,5 @@
   "uuid": "alwaysshowworkspacethumbnails@alynx.one",
   "url": "https://github.com/AlynxZhou/gnome-shell-extension-always-show-workspace-thumbnails/",
   "version": 3,
-  "shell-version": ["40", "41"]
+  "shell-version": ["40", "41", "42"]
 }


### PR DESCRIPTION
The code works fine in GS42. Only the metadata file has to be updated.

Fix https://github.com/AlynxZhou/gnome-shell-extension-always-show-workspace-thumbnails/issues/3