### PR TITLE
Add support for GNOME 44

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,5 +4,5 @@
   "uuid": "alwaysshowworkspacethumbnails@alynx.one",
   "url": "https://github.com/AlynxZhou/gnome-shell-extension-always-show-workspace-thumbnails/",
   "version": 5,
-  "shell-version": ["40", "41", "42", "43"]
+  "shell-version": ["40", "41", "42", "43", "44"]
 }


### PR DESCRIPTION
I tested it on Arch Linux with `gnome-unstable/gnome-shell-44.1`, it works fine.