### PR TITLE
Add support for GNOME 50

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,6 +3,6 @@
   "description": "Always show workspace thumbnails even there is only one workspace.",
   "uuid": "alwaysshowworkspacethumbnails@alynx.one",
   "url": "https://github.com/AlynxZhou/gnome-shell-extension-always-show-workspace-thumbnails/",
-  "version": 11,
-  "shell-version": ["45", "46", "47", "48", "49"]
+  "version": 12,
+  "shell-version": ["45", "46", "47", "48", "49", "50"]
 }


### PR DESCRIPTION
After reading [Port Extensions to GNOME Shell 50 ](https://gjs.guide/extensions/upgrading/gnome-shell-50.html )
Add GNOME 50 in shell-versions. Bump version

It works fine without code changes.

Tested on Arch Linux , gnome shell 50.0